### PR TITLE
changes to work with pcluster setup

### DIFF
--- a/actions/actions.tsx
+++ b/actions/actions.tsx
@@ -46,6 +46,8 @@ export const sendMessage = async (
     baseURL: process.env.OPENAI_API_URL, // Allows to set API other than just openai's
     compatibility: 'compatible' // Allows Use of third party OpenAI APIS (Self hosted)
   })
+  
+  const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
 
   const reply = await streamUI({
     model: openai(`${process.env.OPENAI_API_MODEL}`),
@@ -76,7 +78,6 @@ export const sendMessage = async (
         }),
         generate: async function* ({ job }: { job: string }) {
           yield <BotCard>Getting job details for job {job}...</BotCard>;
-          const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
           try {
             const response = await fetch(`${baseURL}/api/slurm/job/${job}`);
             if (!response.ok) {
@@ -115,7 +116,6 @@ export const sendMessage = async (
         }),
         generate: async function* ({ node }: { node: string }) {
           yield <BotCard>Getting node details for node {node}...</BotCard>;
-          const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
           try {
             const response = await fetch(
               `${baseURL}/api/slurm/nodes/state/${node}`

--- a/app/api/slurm/cluster/route.ts
+++ b/app/api/slurm/cluster/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { env } from "process";
 
 export async function GET() {
-   const res = await fetch(
+  const res = await fetch(
     `http://${env.SLURM_SERVER}/slurmdb/${env.SLURM_API_VERSION}/clusters`,
     {
       headers: {

--- a/app/api/slurm/cluster/route.ts
+++ b/app/api/slurm/cluster/route.ts
@@ -1,9 +1,11 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from "next/server";
 import { env } from "process";
 
 export async function GET() {
-  const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurmdb/${env.SLURM_API_VERSION}/clusters`,
+   const res = await fetch(
+    `http://${env.SLURM_SERVER}/slurmdb/${env.SLURM_API_VERSION}/clusters`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/diag/route.ts
+++ b/app/api/slurm/diag/route.ts
@@ -1,9 +1,11 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from "next/server";
 import { env } from "process";
 
 export async function GET() {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurm/${env.SLURM_API_VERSION}/diag`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/diag`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/job/[...id]/route.ts
+++ b/app/api/slurm/job/[...id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurm/${env.SLURM_API_VERSION}/job/${params.id[0]}`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/job/${params.id[0]}`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/job/completed/[...id]/route.ts
+++ b/app/api/slurm/job/completed/[...id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/job/${params.id[0]}`,
+    `http://${env.SLURM_SERVER}/slurmdb/${env.SLURM_API_VERSION}/job/${params.id[0]}`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/job/completed/[...id]/route.ts
+++ b/app/api/slurm/job/completed/[...id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurmdb/${env.SLURM_API_VERSION}/job/${params.id[0]}`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/job/${params.id[0]}`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/jobs/node/[...id]/route.ts
+++ b/app/api/slurm/jobs/node/[...id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/jobs?node=${params.id[0]}&state=running`,
+    `http://${env.SLURM_SERVER}/slurmdb/${env.SLURM_API_VERSION}/jobs?node=${params.id[0]}&state=running`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/jobs/node/[...id]/route.ts
+++ b/app/api/slurm/jobs/node/[...id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurmdb/${env.SLURM_API_VERSION}/jobs?node=${params.id[0]}&state=running`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/jobs?node=${params.id[0]}&state=running`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/jobs/route.ts
+++ b/app/api/slurm/jobs/route.ts
@@ -3,7 +3,7 @@ import { env } from "process";
 
 export async function GET() {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurm/${env.SLURM_API_VERSION}/jobs`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/jobs`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/jobs/user/[...id]/route.ts
+++ b/app/api/slurm/jobs/user/[...id]/route.ts
@@ -5,9 +5,8 @@ export async function GET(
   req: Request,
   { params }: { params: { id: string } }
 ) {
-  const urlz = `http://${env.SLURM_SERVER}:6820/slurmdb/${env.SLURM_API_VERSION}/jobs?users=${params.id[0]}&state=running`
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurmdb/${env.SLURM_API_VERSION}/jobs?users=${params.id[0]}&state=running`,
+    `http://${env.SLURM_SERVER}/slurmdb/${env.SLURM_API_VERSION}/jobs?users=${params.id[0]}&state=running`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/nodes/route.ts
+++ b/app/api/slurm/nodes/route.ts
@@ -3,7 +3,7 @@ import { env } from "process";
 
 export async function GET() {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurm/${env.SLURM_API_VERSION}/nodes`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/nodes`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/app/api/slurm/nodes/state/[...id]/route.ts
+++ b/app/api/slurm/nodes/state/[...id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurm/${env.SLURM_API_VERSION}/node/${params.id[0]}`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/node/${params.id[0]}`,
     {
       method: "GET",
       headers: {
@@ -30,9 +30,8 @@ export async function POST(
       state: `${body.state}`,
       reason: `${body.reason}`,
     };
-
     const response = await fetch(
-      `http://${env.SLURM_SERVER}:6820/slurm/${env.SLURM_API_VERSION}/node/${params.id[0]}`,
+      `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/node/${params.id[0]}`,
       {
         method: "POST",
         headers: {

--- a/app/api/slurm/reservations/route.ts
+++ b/app/api/slurm/reservations/route.ts
@@ -3,7 +3,7 @@ import { env } from "process";
 
 export async function GET() {
   const res = await fetch(
-    `http://${env.SLURM_SERVER}:6820/slurm/${env.SLURM_API_VERSION}/reservations`,
+    `http://${env.SLURM_SERVER}/slurm/${env.SLURM_API_VERSION}/reservations`,
     {
       headers: {
         "X-SLURM-USER-NAME": `${env.SLURM_API_ACCOUNT}`,

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -5,7 +5,8 @@ import { Skeleton } from "../ui/skeleton";
 
 // Updated fetcher function with error handling
 const fetcher = async () => {
-  const response = await fetch("/api/slurm/diag", {
+  const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
+  const response = await fetch(`${baseURL}/api/slurm/diag`, {
     headers: { "Content-Type": "application/json" },
   });
   if (!response.ok) {

--- a/components/job-search.tsx
+++ b/components/job-search.tsx
@@ -37,6 +37,7 @@ const JobSearch = () => {
   const [searchID, setSearchID] = useState("");
   const { errors } = form.formState;
 
+  const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
   const handleSearch = async (data: SearchFormData) => {
     // Prevent duplicate searches while loading
     if (searchLoading) return;
@@ -51,7 +52,7 @@ const JobSearch = () => {
         // Check for active job
         try {
           const activeJobResponse = await fetch(
-            `/api/slurm/job/${trimmedSearchID}`,
+            `${baseURL}/api/slurm/job/${trimmedSearchID}`,
             {
               headers: {
                 "Content-Type": "application/json",
@@ -134,7 +135,7 @@ const JobSearch = () => {
 
   const fetchMaintenanceData = async () => {
     try {
-      const response = await fetch(`/api/slurm/reservations`, {
+      const response = await fetch(`${baseURL}/api/slurm/reservations`, {
         headers: {
           "Content-Type": "application/json",
         },

--- a/components/modals/card-job-modal.tsx
+++ b/components/modals/card-job-modal.tsx
@@ -30,6 +30,8 @@ const NodeCardModal: React.FC<NodeCardModalProps> = ({
   const [metricValue, setMetricValue] = useState("node_load15");
   const [daysValue, setDaysValue] = useState("3");
 
+  const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
+
   const slurmURL = `/api/slurm/jobs/node/${nodename}`;
   const jobFetcher = () =>
     fetch(slurmURL, {
@@ -69,7 +71,7 @@ const NodeCardModal: React.FC<NodeCardModalProps> = ({
     error: jobDetailsError,
     isLoading: jobDetailsIsLoading,
   } = useSWR<{ jobs: JobDetails[] }>(
-    expandedJobId ? `/api/slurm/job/${expandedJobId}` : null,
+    expandedJobId ? `${baseURL}/api/slurm/job/${expandedJobId}` : null,
     (url: any) =>
       fetch(url, {
         headers: { "Content-Type": "application/json" },
@@ -239,7 +241,7 @@ const NodeCardModal: React.FC<NodeCardModalProps> = ({
                           {job.qos}
                         </TableCell>
                         <TableCell>
-                          {convertUnixToHumanReadable(job.time.start)}
+			                    {convertUnixToHumanReadable(job?.time?.start)}
                         </TableCell>
                         <TableCell className="flex justify-end">
                           {expandedJobId === job.job_id ? (
@@ -308,9 +310,11 @@ const NodeCardModal: React.FC<NodeCardModalProps> = ({
                                     <div>
                                       <p className="font-semibold">State</p>
                                       <p>
-                                        {jobDetails.jobs[0].job_state.join(
-                                          ", "
-                                        )}
+                                        {
+                                            Array.isArray(jobDetails?.jobs?.[0]?.job_state)
+                                              ? jobDetails.jobs[0].job_state.join(", ")
+                                              : jobDetails?.jobs?.[0]?.job_state ?? ""
+                                        }	
                                       </p>
                                     </div>
                                     <div>
@@ -417,7 +421,7 @@ const NodeCardModal: React.FC<NodeCardModalProps> = ({
                       Total Number of jobs running on system:{" "}
                       {
                         jobData?.jobs.filter((job: Job) =>
-                          job.state.current.includes("RUNNING")
+                          job?.state?.current.includes("RUNNING")
                         ).length
                       }
                     </TableCell>

--- a/components/modals/job-detail-modal.tsx
+++ b/components/modals/job-detail-modal.tsx
@@ -19,8 +19,9 @@ const JobDetailModal: React.FC<JobDetailModalProps> = ({
   setOpen,
   searchID,
 }) => {
+  const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
   const jobFetcher = () =>
-    fetch(`/slurmdashboard/api/slurm/job/${searchID}`, {
+    fetch(`${baseURL}/api/slurm/job/${searchID}`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -32,7 +33,7 @@ const JobDetailModal: React.FC<JobDetailModalProps> = ({
     isLoading: jobIsLoading,
   } = useSWR<{
     jobs: RunningJob[];
-  }>(open ? `/slurmdashboard/api/slurm/job/${searchID}` : null, jobFetcher);
+  }>(open ? `${baseURL}/api/slurm/job/${searchID}` : null, jobFetcher);
 
   function convertUnixToHumanReadable(unixTimestamp: number) {
     const date = new Date(unixTimestamp * 1000);

--- a/components/modals/job-detail-modal.tsx
+++ b/components/modals/job-detail-modal.tsx
@@ -20,7 +20,7 @@ const JobDetailModal: React.FC<JobDetailModalProps> = ({
   searchID,
 }) => {
   const jobFetcher = () =>
-    fetch(`/api/slurm/job/${searchID}`, {
+    fetch(`/slurmdashboard/api/slurm/job/${searchID}`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -32,7 +32,7 @@ const JobDetailModal: React.FC<JobDetailModalProps> = ({
     isLoading: jobIsLoading,
   } = useSWR<{
     jobs: RunningJob[];
-  }>(open ? `/api/slurm/job/${searchID}` : null, jobFetcher);
+  }>(open ? `/slurmdashboard/api/slurm/job/${searchID}` : null, jobFetcher);
 
   function convertUnixToHumanReadable(unixTimestamp: number) {
     const date = new Date(unixTimestamp * 1000);
@@ -191,7 +191,7 @@ const JobDetailModal: React.FC<JobDetailModalProps> = ({
           </div>
           <div>
             <p className="font-semibold">State</p>
-            <p>{job.job_state?.join(", ")}</p>
+            <p>{(Array.isArray(job.job_state) && job?.job_state) ? job.job_state.join(", ") : job.job_state ?? ""}</p>
           </div>
           <div>
             <p className="font-semibold">Start Time</p>

--- a/components/node-utilization.tsx
+++ b/components/node-utilization.tsx
@@ -11,8 +11,9 @@ export default function NodeUtilization({
   nodeName,
   className,
 }: NodeUtilizationProps) {
+  const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
   const { data, error, isLoading } = useSWR(
-    `/api/prometheus/utilization?node=${nodeName}`,
+    `${baseURL}/api/prometheus/utilization?node=${nodeName}`,
     (url) => fetch(url).then((res) => res.json()),
     {
       refreshInterval: 300000,

--- a/components/nodeCard/gpu-resource.tsx
+++ b/components/nodeCard/gpu-resource.tsx
@@ -31,10 +31,11 @@ const GPUResourcesDisplay: React.FC<GPUResourcesDisplayProps> = ({
   if (!gpuResources) return null;
 
   useEffect(() => {
+    const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
     const fetchUtilization = async () => {
       try {
         const response = await fetch(
-          `/api/prometheus/dcgm?node=${encodeURIComponent(hostname)}`
+          `${baseURL}/api/prometheus/dcgm?node=${encodeURIComponent(hostname)}`
         );
         const result = await response.json();
         if (result.status === 200 && result.data?.length > 0) {

--- a/components/nodeCard/nodes.tsx
+++ b/components/nodeCard/nodes.tsx
@@ -20,7 +20,8 @@ import ChatIcon from "../llm/chat-icon";
 import { openaiPluginMetadata } from "@/actions/plugins";
 import { LogicType } from "@/components/feature-selector";
 
-const nodeURL = "/api/slurm/nodes";
+const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";;
+const nodeURL = `${baseURL}/api/slurm/nodes`;
 const nodeFetcher = async () => {
   const res = await fetch(nodeURL, {
     headers: {

--- a/components/nodeCard/stats.tsx
+++ b/components/nodeCard/stats.tsx
@@ -28,13 +28,14 @@ const Stats = memo(
       boolean | null
     >(null);
     const shouldFetch = isPrometheusAvailable !== false;
+    const baseURL = process.env.NEXT_PUBLIC_BASE_URL || "";
 
     const {
       data: ipmiData,
       error,
       isValidating,
       mutate,
-    } = useSWR(shouldFetch ? "/api/prometheus/ipmi" : null, fetcher, {
+    } = useSWR(shouldFetch ? `${baseURL}/api/prometheus/ipmi` : null, fetcher, {
       fallbackData: { status: 404, data: [], summary: null },
       onError: (err) => {
         console.error("Prometheus endpoint error:", err);


### PR DESCRIPTION
# Overview
This PR is to modify some of the hard coded endpoints/urls so that it could work with our setup in parallel cluster
# Changes
- Added `baseURL` to any of the necessary endpoints
- Stripping out the port in the some of the hard coded slurm API calls(mainly in the `/api/slurm` folder path)

# Notes
- If we plan to continue to use this repo we will need to see if these changes can be made upstream otherwise we can create our own custom `node/nextjs` application
